### PR TITLE
Contributing: Add missing speaker, avatar and reorder urls

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -84,9 +84,18 @@ showcase: |
           <p class="card-text">
             Are you interested in contributing but don’t know where to start? Tag along and be part of the digital sovereign revolution! Everyone is welcome to join.
           </p>
-          <a href="https://collaboraonline.github.io/" title="Contribute" class="card-link">Collabora Online</a>
+          <a href="https://wiki.ubuntu.com/ContributeToUbuntu" title="Contribute" class="card-link">Ubuntu</a>
           <a href="https://nextcloud.com/contribute/" title="Contribute" class="card-link">Nextcloud</a>
+          <a href="https://collaboraonline.github.io/" title="Contribute" class="card-link">Collabora</a>
           <hr class="card-bottom-divider">
+          <a href="https://twitter.com/communiteatime">
+            <img
+              src="/stands/ubuntu/speaker-monicaM.jpg"
+              class="speaker-avatar rounded-circle shadow-sm"
+              style="width: 32px;"
+              alt="Portrait of Monica Ayhens-Madon"
+              title="Monica Ayhens-Madon (Canonical)"
+            /></a>
           <a href="https://twitter.com/MariusQuabeck">
             <img
               src="/stands/ubuntu/speaker-mariusQ.jpg"
@@ -94,17 +103,14 @@ showcase: |
               style="width: 32px;"
               alt="Portrait of Marius Quabeck"
               title="Marius Quabeck (Nextcloud)"
-            />
-          </a>
+            /></a>
           <a href="https://twitter.com/PedroPS">
             <img
             src="/stands/ubuntu/speaker-pedroS.jpg"
             class="speaker-avatar rounded-circle shadow-sm"
             style="width: 32px;"
             alt="Portrait of Pedro Silva"
-            title="Pedro Silva (Collabora)"
-            />
-          </a>
+            title="Pedro Silva (Collabora)"/></a>
         </div>
       </div>
       <div class="card">


### PR DESCRIPTION
Place URLs in terms of importance instead of alphabetically
 - Also use that order for presenters so they correspond to each other
![image](https://user-images.githubusercontent.com/65948705/152546102-16a2f9d4-0899-4049-8c07-4e5410c6497c.png)